### PR TITLE
guid in rss addeded

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,6 +181,7 @@ FeedRead.rss = function(xml, source, callback) {
           , author:    child_data(art, "author")
                     || child_data(art, "dc:creator")
           , link:      child_data(art, "link")
+          , guid:     child_data(art, "guid")
           , feed:      meta
           };
         if (obj.published) obj.published = new Date(obj.published);


### PR DESCRIPTION
For example http://feeds.hipertextual.com/alt1040 guid is original link to article
